### PR TITLE
Fixes supported architectures

### DIFF
--- a/dropbox-sync/config.json
+++ b/dropbox-sync/config.json
@@ -5,6 +5,12 @@
   "description": "Upload your Hass.io backups to Dropbox",
   "url": "https://github.com/danielwelch/hassio-dropbox-sync",
   "startup": "before",
+  "arch": [
+    "aarch64",
+    "amd64",
+    "armhf",
+    "i386"
+  ],
   "stdin": true,
   "hassio_api": true,
   "hassio_role": "manager",


### PR DESCRIPTION
Basically the same as: https://github.com/danielwelch/hassio-zigbee2mqtt/pull/124

A release of the add-on is not needed for this change.