### PR TITLE
Add support to sync other directories from the backup dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
+.idea
 .env
 .venv
 env/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Once you have created the token, copy it into this add-on's configuration under 
 |`oauth_access_token`|Yes|The "app" access token you generated above via the Dropbox UI.|
 |`output`|Yes|The target directory in your Dropbox to which you want to upload. If left empty, defaults to `/`, which represents the top level of directory of your Dropbox.|
 |`keep_last`|No|If set, the number of snapshots to keep locally. If there are more than this number of snapshots stored locally, the older snapshots will be deleted from local storage after being uploaded to Dropbox. If not set, no snapshots are deleted from local storage.|
-|`filetypes`|No|File extensions of files to upload from `/share` directory, seperated by <code>&#124;</code> (ex: `"jpg|png" or "png"`).|
+|`filetypes`|No|File extensions of files to upload from `/share` directory, seperated by <code>&#124;</code><br/>e.g. <code>"jpg&#124;png"</code> or <code>"png"</code>|
+|`additional_backup_dirs`|No|Additional directorues to upload from `/backup` directory, seperated by <code>&#124;</code><br/>e.g. <code>"unifi/autobackup&#124;mydir"</code> or <code>"another-dir"</code>|
 
 Example Configuration:
 ```json

--- a/dropbox-sync/config.json
+++ b/dropbox-sync/config.json
@@ -24,7 +24,7 @@
     "oauth_access_token": "str",
     "output": "str",
     "keep_last": "int(0,)?",
-    "filetypes": "str?"
-  },
-  "image": "dwelch2101/dropbox-sync-{arch}"
+    "filetypes": "str?",
+    "additional_backup_dirs": "str?"
+  }
 }

--- a/dropbox-sync/run.sh
+++ b/dropbox-sync/run.sh
@@ -4,6 +4,7 @@ CONFIG_PATH=/data/options.json
 
 TOKEN=$(jq --raw-output ".oauth_access_token" $CONFIG_PATH)
 OUTPUT_DIR=$(jq --raw-output ".output // empty" $CONFIG_PATH)
+ADDITIONAL_BACKUP_DIRS=$(jq --raw-output ".additional_backup_dirs // empty" $CONFIG_PATH)
 KEEP_LAST=$(jq --raw-output ".keep_last // empty" $CONFIG_PATH)
 FILETYPES=$(jq --raw-output ".filetypes // empty" $CONFIG_PATH)
 
@@ -16,6 +17,11 @@ echo "[Info] Files will be uploaded to: ${OUTPUT_DIR}"
 echo "[Info] Saving OAUTH_ACCESS_TOKEN to /etc/uploader.conf"
 echo "OAUTH_ACCESS_TOKEN=${TOKEN}" >> /etc/uploader.conf
 
+echo "[Config] OUTPUT_DIR=${OUTPUT_DIR}"
+echo "[Config] ADDITIONAL_BACKUP_DIRS=${ADDITIONAL_BACKUP_DIRS}"
+echo "[Config] KEEP_LAST=${KEEP_LAST}"
+echo "[Config] FILETYPES=${FILETYPES}"
+
 echo "[Info] Listening for messages via stdin service call..."
 
 # listen for input
@@ -27,6 +33,14 @@ while read -r msg; do
     if [[ $cmd = "upload" ]]; then
         echo "[Info] Uploading all .tar files in /backup (skipping those already in Dropbox)"
         ./dropbox_uploader.sh -s -f /etc/uploader.conf upload /backup/*.tar "$OUTPUT_DIR"
+        if [[ "$ADDITIONAL_BACKUP_DIRS" ]]; then
+            echo "[Info] additional_backup_dirs option is set to ${ADDITIONAL_BACKUP_DIRS}"
+            export IFS="|"
+            for backup_dir in ${ADDITIONAL_BACKUP_DIRS}; do
+              echo "[Info] backing up ${backup_dir}"
+              ./dropbox_uploader.sh -s -f /etc/uploader.conf upload /backup/${backup_dir} "${OUTPUT_DIR}/${backup_dir}"
+            done
+        fi
         if [[ "$KEEP_LAST" ]]; then
             echo "[Info] keep_last option is set, cleaning up files..."
             python3 /keep_last.py "$KEEP_LAST"
@@ -35,6 +49,7 @@ while read -r msg; do
             echo "[Info] filetypes option is set, scanning share directory for files with extensions ${FILETYPES}"
             find /share -regextype posix-extended -regex "^.*\.(${FILETYPES})" -exec ./dropbox_uploader.sh -s -f /etc/uploader.conf upload {} "$OUTPUT_DIR" \;
         fi
+        echo "[Info] Complete"
     else
         # received undefined command
         echo "[Error] Command not found: ${cmd}"


### PR DESCRIPTION
Some add ons will output their backups in the backup dir (e.g: Unifi Controller)
This adds support to pick up those additional dirs and sync them to dropbox.