### PR TITLE
Change startup before to startup services

### DIFF
--- a/dropbox-sync/config.json
+++ b/dropbox-sync/config.json
@@ -4,7 +4,7 @@
   "slug": "dropbox_sync",
   "description": "Upload your Hass.io backups to Dropbox",
   "url": "https://github.com/danielwelch/hassio-dropbox-sync",
-  "startup": "before",
+  "startup": "services",
   "arch": [
     "aarch64",
     "amd64",


### PR DESCRIPTION
Resolve the following Warning:
WARNING (SyncWorker_1) [supervisor.addons.validate] Add-on config 'startup' with 'before' is deprecated. Please report this to the maintainer of Dropbox Sync